### PR TITLE
Fix openssl formula path for openresty

### DIFF
--- a/Formula/openresty.rb
+++ b/Formula/openresty.rb
@@ -22,8 +22,8 @@ class Openresty < Formula
 
   def install
     # Configure
-    cc_opt = "-I#{HOMEBREW_PREFIX}/include -I#{Formula["pcre"].opt_include} -I#{Formula["openresty-openssl"].opt_include}"
-    ld_opt = "-L#{HOMEBREW_PREFIX}/lib -L#{Formula["pcre"].opt_lib} -L#{Formula["openresty-openssl"].opt_lib}"
+    cc_opt = "-I#{HOMEBREW_PREFIX}/include -I#{Formula["pcre"].opt_include} -I#{Formula["openresty/brew/openresty-openssl"].opt_include}"
+    ld_opt = "-L#{HOMEBREW_PREFIX}/lib -L#{Formula["pcre"].opt_lib} -L#{Formula["openresty/brew/openresty-openssl"].opt_lib}"
 
     args = %W[
       --prefix=#{prefix}

--- a/Formula/openresty.rb
+++ b/Formula/openresty.rb
@@ -10,10 +10,10 @@ class Openresty < Formula
   option "with-iconv", "Compile with ngx_http_iconv_module"
   option "with-slice", "Compile with ngx_http_slice_module"
 
+  depends_on "geoip"
+  depends_on "openresty/brew/openresty-openssl"
   depends_on "pcre"
   depends_on "postgresql" => :optional
-  depends_on "openresty/brew/openresty-openssl"
-  depends_on "geoip"
 
   skip_clean "site"
   skip_clean "pod"
@@ -79,27 +79,28 @@ class Openresty < Formula
 
   plist_options :manual => "openresty"
 
-  def plist; <<~EOS
-    <?xml version="1.0" encoding="UTF-8"?>
-    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-    <plist version="1.0">
-      <dict>
-        <key>Label</key>
-        <string>#{plist_name}</string>
-        <key>RunAtLoad</key>
-        <true/>
-        <key>KeepAlive</key>
-        <false/>
-        <key>ProgramArguments</key>
-        <array>
-            <string>#{opt_prefix}/bin/openresty</string>
-            <string>-g</string>
-            <string>daemon off;</string>
-        </array>
-        <key>WorkingDirectory</key>
-        <string>#{HOMEBREW_PREFIX}</string>
-      </dict>
-    </plist>
+  def plist
+    <<~EOS
+      <?xml version="1.0" encoding="UTF-8"?>
+      <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+      <plist version="1.0">
+        <dict>
+          <key>Label</key>
+          <string>#{plist_name}</string>
+          <key>RunAtLoad</key>
+          <true/>
+          <key>KeepAlive</key>
+          <false/>
+          <key>ProgramArguments</key>
+          <array>
+              <string>#{opt_prefix}/bin/openresty</string>
+              <string>-g</string>
+              <string>daemon off;</string>
+          </array>
+          <key>WorkingDirectory</key>
+          <string>#{HOMEBREW_PREFIX}</string>
+        </dict>
+      </plist>
     EOS
   end
 

--- a/Formula/openresty.rb
+++ b/Formula/openresty.rb
@@ -93,9 +93,9 @@ class Openresty < Formula
           <false/>
           <key>ProgramArguments</key>
           <array>
-              <string>#{opt_prefix}/bin/openresty</string>
-              <string>-g</string>
-              <string>daemon off;</string>
+            <string>#{opt_prefix}/bin/openresty</string>
+            <string>-g</string>
+            <string>daemon off;</string>
           </array>
           <key>WorkingDirectory</key>
           <string>#{HOMEBREW_PREFIX}</string>


### PR DESCRIPTION
### Have you:

- [x] Followed the guidelines in our [Contributing](https://github.com/denji/homebrew-nginx/blob/master/.github/CONTRIBUTING.md) document?
- [x] Checked to ensure there aren't other open [Pull Requests](https://github.com/denji/homebrew-nginx/pulls) for the same update/change?
- [x] Run `brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting) and corrected all errors?
- [x] Built your formula locally prior to submission with `brew install <formula>`?

### Updates to existing formula: have you

- [x] Removed the `revision` line, if any, when bumping the version number?
- [x] Added/bumped the `revision` number if the changes affect the precompiled bottles?
- [x] Not altered the `bottle` section?
- [x] Checked that the tests still pass?

### Changes

When install with `brew install --with-debug openresty/brew/openresty`, following error occurs:
```
Error: An exception occurred within a child process:
  TapFormulaAmbiguityError: Formulae found in multiple taps:
       * openresty/brew/openresty-openssl
       * denji/nginx/openresty-openssl
       * homebrew/nginx/openresty-openssl
```
The PR fixes above error by specifying `openresty/brew/openresty-openssl` in line 25 and 26. 
Other changes are all for passing `brew audit --strict --online openresty/brew/openresty`.
