### PR TITLE
Call service.require_root method in lieu of deprecated plist_options method.

### DIFF
--- a/Formula/openresty.rb
+++ b/Formula/openresty.rb
@@ -77,7 +77,7 @@ class Openresty < Formula
     system "make", "install"
   end
 
-  plist_options :manual => "openresty"
+  service.require_root :manual => "openresty"
 
   def plist
     <<~EOS


### PR DESCRIPTION
openresty: Fix formula to call service.require_root method in lieu of deprecated service.require_root method

### Have you:

- [ ] Followed the guidelines in our [Contributing](https://github.com/denji/homebrew-nginx/blob/master/.github/CONTRIBUTING.md) document?
- [ ] Checked to ensure there aren't other open [Pull Requests](https://github.com/denji/homebrew-nginx/pulls) for the same update/change?
- [ ] Run `brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting) and corrected all errors?
- [ ] Built your formula locally prior to submission with `brew install <formula>`?

### New formula: have you

- [x] Written a sensible test? (The best test is to compile and run a sample program.)

### Updates to existing formula: have you

- [ ] Removed the `revision` line, if any, when bumping the version number?
- [x] Added/bumped the `revision` number if the changes affect the precompiled bottles?
- [x] Not altered the `bottle` section?
- [ ] Checked that the tests still pass?
